### PR TITLE
Update vim.markdown

### DIFF
--- a/vim.markdown
+++ b/vim.markdown
@@ -482,7 +482,7 @@ run the command every time you log in.
 ---
 # built-in escape alternative
 
-You can also use ctrl+`]` to get out of insert mode.
+You can also use alt+`]` to get out of insert mode.
 
 ---
 # EOF


### PR DESCRIPTION
it's alt+']' for exiting insert mode in vim